### PR TITLE
Improvements on phone finder action

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,7 @@
         android:required="true" />
 
     <application
+        android:name=".App"
         android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.CALL_PHONE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.READ_CALENDAR" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         tools:ignore="ScopedStorage" />
@@ -38,7 +39,12 @@
         android:theme="@style/AppTheme"
         tools:ignore="GoogleAppIndexingWarning">
 
-        <service android:name=".utils.ForegroundService" />
+        <service android:name=".utils.ForegroundService" android:enabled="true"/>
+        <receiver android:name=".utils.ForegroundService$Autostart" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
         <receiver android:name=".utils.PhoneFinder" />
 
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,7 @@
         tools:ignore="GoogleAppIndexingWarning">
 
         <service android:name=".utils.ForegroundService" />
+        <receiver android:name=".utils.PhoneFinder" />
 
         <activity
             android:name="org.avmedia.gShockPhoneSync.MainActivity"

--- a/app/src/main/java/org/avmedia/gShockPhoneSync/App.kt
+++ b/app/src/main/java/org/avmedia/gShockPhoneSync/App.kt
@@ -7,6 +7,6 @@ import org.avmedia.gShockPhoneSync.utils.ForegroundService
 class App : Application() {
     override fun onCreate() {
         super.onCreate()
-        startService(Intent(this, ForegroundService::class.java))
+        startForegroundService(Intent(this, ForegroundService::class.java))
     }
 }

--- a/app/src/main/java/org/avmedia/gShockPhoneSync/App.kt
+++ b/app/src/main/java/org/avmedia/gShockPhoneSync/App.kt
@@ -1,0 +1,12 @@
+package org.avmedia.gShockPhoneSync
+
+import android.app.Application
+import android.content.Intent
+import org.avmedia.gShockPhoneSync.utils.ForegroundService
+
+class App : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        startService(Intent(this, ForegroundService::class.java))
+    }
+}

--- a/app/src/main/java/org/avmedia/gShockPhoneSync/MainActivity.kt
+++ b/app/src/main/java/org/avmedia/gShockPhoneSync/MainActivity.kt
@@ -16,6 +16,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
+import android.view.View
 import android.view.WindowManager
 import android.widget.LinearLayout
 import android.widget.TextView
@@ -97,8 +98,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun runWithChecks() {
-
-        findNavController(R.id.nav_host_fragment_activity_gshock_screens)
+        navigateHome()
 
         if (!isBluetoothEnabled()!!) {
             turnOnBLE()
@@ -240,24 +240,18 @@ class MainActivity : AppCompatActivity() {
                         Utils.snackBar(
                             this, "Actions not granted...Cannot access the Actions screen..."
                         )
-                        val navController =
-                            findNavController(R.id.nav_host_fragment_activity_gshock_screens)
-                        navController.navigate(R.id.navigation_home)
+                        navigateHome()
                     }
 
                     ProgressEvents["CalendarPermissionsNotGranted"] -> {
                         Utils.snackBar(
                             this, "Calendar not granted...Cannot access the Actions screen..."
                         )
-                        val navController =
-                            findNavController(R.id.nav_host_fragment_activity_gshock_screens)
-                        navController.navigate(R.id.navigation_home)
+                        navigateHome()
                     }
 
                     ProgressEvents["WatchInitializationCompleted"] -> {
-                        val navController =
-                            findNavController(R.id.nav_host_fragment_activity_gshock_screens)
-                        navController.navigate(R.id.navigation_home)
+                        navigateHome()
                     }
 
                     ProgressEvents["HomeTimeUpdated"] -> {
@@ -273,6 +267,14 @@ class MainActivity : AppCompatActivity() {
                 Timber.d("Got error on subscribe: $throwable")
                 throwable.printStackTrace()
             })
+    }
+
+    private fun navigateHome() {
+        if (findViewById<View>(R.id.nav_host_fragment_activity_gshock_screens) != null) {
+            val navController =
+                findNavController(R.id.nav_host_fragment_activity_gshock_screens)
+            navController.navigate(R.id.navigation_home)
+        }
     }
 
     private suspend fun waitForConnectionCached() {

--- a/app/src/main/java/org/avmedia/gShockPhoneSync/PermissionManager.kt
+++ b/app/src/main/java/org/avmedia/gShockPhoneSync/PermissionManager.kt
@@ -34,6 +34,9 @@ data class PermissionManager(val context: Context) {
             PERMISSIONS += Manifest.permission.BLUETOOTH_SCAN
             PERMISSIONS += Manifest.permission.BLUETOOTH_CONNECT
         }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            PERMISSIONS += Manifest.permission.POST_NOTIFICATIONS
+        }
     }
 
     private fun hasPermissions(context: Context, permissions: Array<String>): Boolean =

--- a/app/src/main/java/org/avmedia/gShockPhoneSync/PermissionManager.kt
+++ b/app/src/main/java/org/avmedia/gShockPhoneSync/PermissionManager.kt
@@ -27,6 +27,7 @@ data class PermissionManager(val context: Context) {
     private var PERMISSION_ALL = 1
     private var PERMISSIONS = arrayOf(
         Manifest.permission.ACCESS_FINE_LOCATION,
+        Manifest.permission.RECEIVE_BOOT_COMPLETED,
     )
 
     init {

--- a/app/src/main/java/org/avmedia/gShockPhoneSync/ui/actions/ActionsModel.kt
+++ b/app/src/main/java/org/avmedia/gShockPhoneSync/ui/actions/ActionsModel.kt
@@ -7,14 +7,10 @@
 package org.avmedia.gShockPhoneSync.ui.actions
 
 import android.app.Activity
-import android.app.AlertDialog
 import android.app.NotificationManager
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
-import android.media.AudioAttributes
-import android.media.MediaPlayer
-import android.media.RingtoneManager
 import android.net.Uri
 import androidx.camera.core.CameraSelector
 import com.google.gson.Gson
@@ -26,7 +22,6 @@ import org.avmedia.gShockPhoneSync.utils.*
 import org.avmedia.gshockapi.WatchInfo
 import timber.log.Timber
 import java.io.File
-import java.io.IOException
 import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.time.Clock
@@ -115,36 +110,7 @@ object ActionsModel {
 
         override fun run(context: Context) {
             Timber.d("running ${this.javaClass.simpleName}")
-
-            var alarmUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)
-            if (alarmUri == null) {
-                alarmUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)
-            }
-            if (alarmUri == null) {
-                Timber.e("ringAlarm", "Unable to get default sound URI")
-                return
-            }
-            val mp = MediaPlayer()
-            mp.setAudioAttributes(
-                AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_ALARM).build()
-            )
-            try {
-                mp.setDataSource(context, alarmUri)
-                mp.prepare()
-                mp.start()
-                mp.isLooping = true
-                AlertDialog.Builder(context)
-                    .setTitle("Find phone")
-                    .setMessage("Stop ringing?")
-                    .setPositiveButton("STOP!") { dialog, _ ->
-                        mp.stop(); dialog.cancel()
-                    }
-                    .setCancelable(false)
-                    .create()
-                    .show()
-            } catch (e: IOException) {
-                Timber.e(e)
-            }
+            PhoneFinder.ring(context)
         }
 
         override fun load(context: Context) {

--- a/app/src/main/java/org/avmedia/gShockPhoneSync/utils/ForegroundService.kt
+++ b/app/src/main/java/org/avmedia/gShockPhoneSync/utils/ForegroundService.kt
@@ -3,6 +3,7 @@ package org.avmedia.gShockPhoneSync.utils
 import android.R
 import android.app.*
 import android.app.Notification.Builder
+import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.content.Intent
 import android.os.IBinder
 import org.avmedia.gShockPhoneSync.MainActivity
@@ -16,7 +17,7 @@ class ForegroundService : Service() {
             this, 0, Intent(
                 this,
                 MainActivity::class.java
-            ), 0
+            ), FLAG_IMMUTABLE
         )
         val notification: Notification = Builder(applicationContext, CHANNEL_ID)
             .setContentTitle("Waiting for Connections")

--- a/app/src/main/java/org/avmedia/gShockPhoneSync/utils/ForegroundService.kt
+++ b/app/src/main/java/org/avmedia/gShockPhoneSync/utils/ForegroundService.kt
@@ -24,7 +24,6 @@ class ForegroundService : Service() {
             .setContentText(input)
             .setSmallIcon(R.drawable.ic_menu_day)
             .setContentIntent(pendingIntent)
-            .setOngoing(true)
             .build()
 
         startForeground(1, notification)

--- a/app/src/main/java/org/avmedia/gShockPhoneSync/utils/ForegroundService.kt
+++ b/app/src/main/java/org/avmedia/gShockPhoneSync/utils/ForegroundService.kt
@@ -24,6 +24,7 @@ class ForegroundService : Service() {
             .setContentText(input)
             .setSmallIcon(R.drawable.ic_menu_day)
             .setContentIntent(pendingIntent)
+            .setOngoing(true)
             .build()
 
         startForeground(1, notification)

--- a/app/src/main/java/org/avmedia/gShockPhoneSync/utils/ForegroundService.kt
+++ b/app/src/main/java/org/avmedia/gShockPhoneSync/utils/ForegroundService.kt
@@ -4,6 +4,8 @@ import android.R
 import android.app.*
 import android.app.Notification.Builder
 import android.app.PendingIntent.FLAG_IMMUTABLE
+import android.content.BroadcastReceiver
+import android.content.Context
 import android.content.Intent
 import android.os.IBinder
 import org.avmedia.gShockPhoneSync.MainActivity
@@ -44,4 +46,11 @@ class ForegroundService : Service() {
         )
         getSystemService(NotificationManager::class.java).createNotificationChannel(serviceChannel)
     }
+
+    class Autostart : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            context.startForegroundService(Intent(context, ForegroundService::class.java))
+        }
+    }
 }
+

--- a/app/src/main/java/org/avmedia/gShockPhoneSync/utils/PhoneFinder.kt
+++ b/app/src/main/java/org/avmedia/gShockPhoneSync/utils/PhoneFinder.kt
@@ -1,0 +1,94 @@
+package org.avmedia.gShockPhoneSync.utils
+
+import org.avmedia.gShockPhoneSync.R
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.media.AudioAttributes
+import android.media.AudioManager
+import android.media.MediaPlayer
+import android.media.RingtoneManager
+import androidx.core.app.NotificationCompat
+import timber.log.Timber
+
+class PhoneFinder : BroadcastReceiver() {
+    companion object {
+        val CHANNEL_ID = "G_SHOCK_PHONE_FINDER_CHANNEL"
+        var mp: MediaPlayer? = null
+
+        fun ring(context: Context) {
+            // get alarm uri
+            var alarmUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)
+            if (alarmUri == null) {
+                alarmUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)
+            }
+            if (alarmUri == null) {
+                Timber.e("ringAlarm", "Unable to get default sound URI")
+                return
+            }
+
+            // set volume to maximum
+            val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+            while (
+                audioManager.getStreamVolume(AudioManager.STREAM_ALARM) <
+                audioManager.getStreamMaxVolume(AudioManager.STREAM_ALARM)
+            ) {
+                audioManager.adjustStreamVolume(
+                    AudioManager.STREAM_ALARM,
+                    AudioManager.ADJUST_RAISE,
+                    AudioManager.FLAG_PLAY_SOUND
+                )
+            }
+
+            // init media player
+            mp = MediaPlayer()
+            mp!!.setAudioAttributes(
+                AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_ALARM).build()
+            )
+            mp!!.setDataSource(context, alarmUri)
+            mp!!.prepare()
+            mp!!.start()
+            mp!!.isLooping = true
+
+            // create stop ringing notification
+            val notificationManager: NotificationManager = context.applicationContext
+                .getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.createNotificationChannel(
+                NotificationChannel(
+                    CHANNEL_ID,
+                    "G-Shock Phone Finder",
+                    NotificationManager.IMPORTANCE_HIGH
+                )
+            )
+            notificationManager.notify(
+                0,
+                NotificationCompat.Builder(context, CHANNEL_ID)
+                    .setSmallIcon(R.drawable.ring)
+                    .setContentTitle("Phone finder")
+                    .setContentText("Swipe to stop ringing")
+                    .setDeleteIntent(
+                        PendingIntent.getBroadcast(
+                            context,
+                            0,
+                            Intent(context, PhoneFinder::class.java),
+                            PendingIntent.FLAG_IMMUTABLE
+                        )
+                    )
+                    .setPriority(NotificationCompat.PRIORITY_MAX)
+                    .build()
+            )
+        }
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        // stop ringing
+        if (mp != null) {
+            mp!!.stop()
+            mp = null
+        }
+    }
+
+}

--- a/app/src/main/java/org/avmedia/gShockPhoneSync/utils/PhoneFinder.kt
+++ b/app/src/main/java/org/avmedia/gShockPhoneSync/utils/PhoneFinder.kt
@@ -87,6 +87,7 @@ class PhoneFinder : BroadcastReceiver() {
         // stop ringing
         if (mp != null) {
             mp!!.stop()
+            mp!!.release()
             mp = null
         }
     }


### PR DESCRIPTION
This pull request builds upon #40 and addresses:
1. ForegroundService not starting automatically (at least on my phone)
2. Notification instead of AlertDialog because otherwise the phone keeps ringing in loop and cannot be stopped (when app's activity is not active but it's just listening through the foreground service).
3. PhoneFinder as a standalone utils class / object, like Flashlight or CameraCapture.
